### PR TITLE
Add Multi-Session Tag support and example

### DIFF
--- a/examples/UWB_MultiSessionTag1/UWB_MultiSessionTag1.ino
+++ b/examples/UWB_MultiSessionTag1/UWB_MultiSessionTag1.ino
@@ -1,0 +1,89 @@
+#include <PortentaUWBShield.h>
+
+/**
+ * Multi-Session Tag 1 Demo (Portenta as Tag)
+ * 
+ * This demo shows how to setup the Arduino Portenta C33 with UWB Shield as 
+ * Tag 1 that participates in a multi-session ranging system. This tag connects 
+ * to the anchor's Session 1 (0x111111).
+ * 
+ * Configuration must match the anchor's Session 1:
+ * - Session ID: 0x111111
+ * - Tag MAC: 0x2222
+ * - Anchor MAC: 0x1111
+ * - Preamble Code: 10
+ * 
+ * The anchor can simultaneously track this tag along with other tags on 
+ * different sessions.
+ * 
+ * It expects a counterpart Portenta device setup as a Multi-Session Anchor
+ * 
+ */
+
+// handler for ranging notifications
+void rangingHandler(UWBRangingData &rangingData) {
+  Serial.print("GOT RANGING DATA - Type: ");
+  Serial.println(rangingData.measureType());
+  
+  if(rangingData.measureType()==(uint8_t)uwb::MeasurementType::TWO_WAY)
+  {
+    RangingMeasures twr=rangingData.twoWayRangingMeasure();
+    for(int j=0;j<rangingData.available();j++)
+    {
+      if(twr[j].status==0 && twr[j].distance!=0xFFFF)
+      {
+        Serial.print("Distance: ");
+        Serial.println(twr[j].distance);  
+      }
+    }
+  }
+}
+
+void setup()
+{
+  Serial.begin(115200);
+
+#if defined(ARDUINO_PORTENTA_C33)
+  /* Only the Portenta C33 has an RGB LED. */
+  pinMode(LEDR, OUTPUT);
+  digitalWrite(LEDR, LOW);
+#endif
+
+  //define the source (this device) and destination MAC addresses, using 2-bytes MACs
+  uint8_t devAddr[] = {0x22, 0x22};
+  uint8_t destination[] = {0x11, 0x11};
+  UWBMacAddress srcAddr(UWBMacAddress::Size::SHORT, devAddr);
+  UWBMacAddress dstAddr(UWBMacAddress::Size::SHORT, destination);
+
+  // register the ranging notification handler before starting
+  UWB.registerRangingCallback(rangingHandler);
+  
+  UWB.begin(); //start the UWB stack, use Serial for the log output
+  Serial.println("Starting UWB ...");
+  
+  //wait until the stack is initialised
+  while(UWB.state()!=0)
+    delay(10);
+
+  Serial.println("Starting session ...");
+  //setup a session with ID 0x111111, using preamble code 10
+  UWBMultiSessionTag myTag(0x111111, srcAddr, dstAddr, 10);
+
+  //add the session to the session manager
+  UWBSessionManager.addSession(myTag);
+
+  //prepare the session applying the configured parameters
+  myTag.init();
+  
+  //start the session
+  myTag.start();
+}
+
+void loop()
+{
+#if defined(ARDUINO_PORTENTA_C33)
+  /* Only the Portenta C33 has an RGB LED. */
+  digitalWrite(LEDR, !digitalRead(LEDR));
+#endif
+  delay(1000);
+}

--- a/src/PortentaUWBShield.h
+++ b/src/PortentaUWBShield.h
@@ -8,6 +8,7 @@
 #include "uwbapps/UWBRangingController.hpp"
 #include "uwbapps/UWBRangingOneToMany.hpp"
 #include "uwbapps/UWBMultiSessionAnchor.hpp"
+#include "uwbapps/UWBMultiSessionTag.hpp"
 #include "uwbapps/UWBUltdoaAnchor.hpp"
 #include "uwbapps/UWBUltdoaSyncAnchor.hpp"
 #endif

--- a/src/uwbapps/UWBMultiSessionTag.hpp
+++ b/src/uwbapps/UWBMultiSessionTag.hpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Truesense Srl
+
+#ifndef UWBMULTISESSIONTAG_HPP
+#define UWBMULTISESSIONTAG_HPP
+
+#include "hal/uwb_hal.hpp"
+#include "UWB.hpp"
+#include "UWBSession.hpp"
+
+/**
+ * @brief Multi-Session Tag class for participating in multi-anchor systems
+ * 
+ * This class creates a UWB tag that participates in a multi-session ranging
+ * system. The tag connects to an anchor running multiple concurrent sessions,
+ * allowing the anchor to track multiple tags simultaneously.
+ * 
+ * Each tag must be configured with parameters matching its designated session
+ * on the anchor, including unique session ID, MAC addresses, and preamble code.
+ * 
+ * Typical use case: Individual asset tags in a warehouse, personnel tracking
+ * badges, or mobile robots in factory automation.
+ */
+class UWBMultiSessionTag : public UWBSession {
+
+public:   
+    /**
+     * @brief Construct a multi-session tag for a specific session
+     * 
+     * @param session_ID Unique identifier matching the anchor's session (e.g., 0x111111)
+     * @param srcAddr MAC address of this tag
+     * @param dstAddr MAC address of the target anchor for this session
+     * @param preambleCode Preamble code (must match anchor's session configuration)
+     */
+    UWBMultiSessionTag(uint32_t session_ID, UWBMacAddress srcAddr, 
+                       UWBMacAddress dstAddr, uint8_t preambleCode = 10)
+    {
+        sessionID(session_ID);
+		sessionType(uwb::SessionType::RANGING);
+		rangingParams.deviceRole(uwb::DeviceRole::INITIATOR);
+		rangingParams.deviceType(uwb::DeviceType::CONTROLLER);
+		rangingParams.multiNodeMode(uwb::MultiNodeMode::UNICAST);
+		rangingParams.rangingRoundUsage(uwb::RangingMethod::DS_TWR);
+		rangingParams.scheduledMode(uwb::ScheduledMode::TIME_SCHEDULED);
+		rangingParams.macAddrMode((uint8_t)uwb::MacAddressMode::SHORT);
+		rangingParams.deviceMacAddr(srcAddr);
+		
+		
+		
+	    appParams.destinationMacAddr(dstAddr);
+	    appParams.frameConfig(uwb::RfFrameConfig::SP3);
+		appParams.slotPerRR(25);
+		appParams.rangingDuration(200);
+		appParams.stsConfig(uwb::StsConfig::StaticSts);
+		appParams.stsSegments(1);
+		appParams.sfdId(2);
+		appParams.preambleCodeIndex(10);
+    }      		
+};
+
+#endif /* UWBMULTISESSIONTAG_HPP */


### PR DESCRIPTION
Introduces UWBMultiSessionTag class for multi-session ranging systems, allowing a tag to connect to a specific anchor session. Adds UWB_MultiSessionTag1.ino example demonstrating usage, and updates PortentaUWBShield.h to include the new class.