### PR TITLE
Fix library packaging for latest Arduino core and add In-Band data tr…

### DIFF
--- a/examples/UWB_InbandDataRx/UWB_InbandDataRx.ino
+++ b/examples/UWB_InbandDataRx/UWB_InbandDataRx.ino
@@ -1,0 +1,152 @@
+#include <PortentaUWBShield.h>
+
+
+/**
+ * This example demonstrates UWB in-band data reception during ranging.
+ * 
+ * Overview:
+ * - Establishes a UWB Session between two devices.
+ * - Receives data payloads piggybacked on ranging packets.
+ * - This example acts as the RECEIVER (RX).
+ * 
+ * Features:
+ * - Raw Buffer Parsing: Explicitly parses the raw DataPacket buffer to extract Sequence, Size, and Payload.
+ * - Latency Measurement: A GPIO pulse is generated on PIN 3 immediately upon data reception.
+ *   Connect a Logic Analyzer to PIN 3 to measure the exact time the packet arrives at the app layer.
+ */
+
+// MAC addresses of the devices
+uint8_t devAddr[] = {0x22, 0x22};
+uint8_t destination[] = {0x11, 0x11};
+UWBMacAddress srcAddr(UWBMacAddress::Size::SHORT, devAddr);
+UWBMacAddress dstAddr(UWBMacAddress::Size::SHORT, destination);
+
+UWBInBandDataRx* dataSession;
+
+// Statistics
+uint32_t packetsReceived = 0;
+
+// Data reception callback - read from global buffer!
+void dataRxHandler(uwb::DataPacket& rxData) {
+  // Latency Measurement Pulse
+  // Pulse Pin 3 HIGH for 50us to satisfy logic analyzer trigger
+  digitalWrite(3, HIGH);
+  delayMicroseconds(50);
+  digitalWrite(3, LOW);
+
+  packetsReceived++;
+
+  // The UWB HAL provides a raw buffer pointer cast to DataPacket&.
+  // However, the internal memory layout differs from the DataPacket struct definition.
+  // We parse the raw bytes using known offsets to extract the header and payload.
+  
+  uint8_t* rawData = (uint8_t*)&rxData;
+  
+  // Parse Header
+  // Offset 14-15: Sequence Number
+  // Offset 16-17: Actual Data Size
+  // Offset 18...: Inline Payload Data
+  uint16_t sequenceNumber = *((uint16_t*)&rawData[14]);
+  uint16_t actualSize = *((uint16_t*)&rawData[16]);
+  uint8_t* dataPayload = &rawData[18];
+
+  Serial.print("RX Seq: ");
+  Serial.print(sequenceNumber);
+  Serial.print(" | Size: ");
+  Serial.print(actualSize);
+  
+  // Sanity check size before printing
+  if (actualSize > 0 && actualSize < 120) {
+      Serial.print(" | Data: '");
+      for (uint16_t i = 0; i < actualSize; i++) {
+        char c = (char)dataPayload[i]; 
+        if (c == '\0') break; // Stop at null terminator if string
+        if (isPrintable(c)) {
+            Serial.print(c);
+        } else {
+            Serial.print(".");
+        }
+      }
+      Serial.println("'");
+  } else {
+      Serial.println(" | (Empty/Invalid)");
+  }
+
+#if defined(ARDUINO_PORTENTA_C33)
+  digitalWrite(LEDG, !digitalRead(LEDG));
+#endif
+}
+
+// Ranging callback
+void rangingHandler(UWBRangingData& rangingData) {
+  if (rangingData.measureType() == (uint8_t)uwb::MeasurementType::TWO_WAY) {
+    RangingMeasures twr = rangingData.twoWayRangingMeasure();
+    for (int j = 0; j < rangingData.available(); j++) {
+      if (twr[j].status == 0 && twr[j].distance != 0xFFFF) {
+        Serial.print("Distance: ");
+        Serial.print(twr[j].distance);
+        Serial.println(" cm");
+      }
+    }
+  }
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) delay(10);
+
+#if defined(ARDUINO_PORTENTA_C33)
+  pinMode(LEDG, OUTPUT);
+  pinMode(LEDB, OUTPUT);
+  digitalWrite(LEDG, HIGH);
+  digitalWrite(LEDB, LOW);
+#endif
+
+
+  // Setup Latency Measurement Pin
+  // Connect a Scope/Logic Analyzer to D3
+  pinMode(3, OUTPUT); 
+  digitalWrite(3, LOW);
+
+  Serial.println("=== UWB In-Band Data RX Example ===");
+  Serial.println("Initializing UWB...");
+
+  UWB.registerDataRxCallback(dataRxHandler);
+  UWB.registerRangingCallback(rangingHandler);
+  // Using INFO level for cleaner output. Use UWB_DEBUG_LEVEL for troubleshooting.
+  UWB.begin(Serial, uwb::LogLevel::UWB_INFO_LEVEL);
+
+  while (UWB.state() != 0) {
+    Serial.print(".");
+    delay(100);
+  }
+  Serial.println(" Done!");
+
+  Serial.println("Creating RX session...");
+  dataSession = new UWBInBandDataRx(0x11223344, srcAddr, dstAddr, 12);
+  UWBSessionManager.addSession(*dataSession);
+  dataSession->init();
+  dataSession->start();
+
+  Serial.println("Session started. Firmware will auto-write to global buffer during ranging.");
+  Serial.println("");
+}
+
+void loop() {
+  static unsigned long lastStatusTime = 0;
+  unsigned long currentTime = millis();
+
+  // Status every 10 seconds
+  if (currentTime - lastStatusTime >= 10000) {
+    lastStatusTime = currentTime;
+    Serial.print("Listening... (Packets: ");
+    Serial.print(packetsReceived);
+    Serial.println(")");
+
+#if defined(ARDUINO_PORTENTA_C33)
+    digitalWrite(LEDB, !digitalRead(LEDB));
+#endif
+  }
+
+  delay(100);
+}

--- a/examples/UWB_InbandDataTx/UWB_InbandDataTx.ino
+++ b/examples/UWB_InbandDataTx/UWB_InbandDataTx.ino
@@ -1,0 +1,118 @@
+#include <PortentaUWBShield.h>
+
+
+/**
+ * This example demonstrates UWB in-band data transfer during ranging.
+ * 
+ * Overview:
+ * - Establishes a UWB Session between two devices.
+ * - Sends custom data payloads piggybacked on ranging packets.
+ * - This example acts as the TRANSMITTER (TX).
+ * 
+ * Features:
+ * - Manual Data Send: We update the buffer and trigger sendData() in the loop.
+ * - Latency Measurement: A GPIO pulse is generated on PIN 3 upon successful transmission.
+ *   Connect a Logic Analyzer to PIN 3 to measure the exact time the packet leaves the stack.
+ */
+
+// MAC addresses of the devices
+uint8_t devAddr[] = {0x11, 0x11};
+uint8_t destination[] = {0x22, 0x22};
+UWBMacAddress srcAddr(UWBMacAddress::Size::SHORT, devAddr);
+UWBMacAddress dstAddr(UWBMacAddress::Size::SHORT, destination);
+
+UWBInBandDataTx* dataSession;
+
+// Counter for demo
+uint32_t dataCounter = 0;
+unsigned long lastUpdateTime = 0;
+const unsigned long UPDATE_INTERVAL = 1000;
+
+// Ranging callback
+void rangingHandler(UWBRangingData& rangingData) {
+  if (rangingData.measureType() == (uint8_t)uwb::MeasurementType::TWO_WAY) {
+    RangingMeasures twr = rangingData.twoWayRangingMeasure();
+    for (int j = 0; j < rangingData.available(); j++) {
+      if (twr[j].status == 0 && twr[j].distance != 0xFFFF) {
+        Serial.print("Distance: ");
+        Serial.print(twr[j].distance);
+        Serial.println(" cm");
+      }
+    }
+  }
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) delay(10);
+
+#if defined(ARDUINO_PORTENTA_C33)
+  pinMode(LEDR, OUTPUT);
+  digitalWrite(LEDR, LOW);
+#endif
+
+  // Setup Latency Measurement Pin
+  // Connect a Scope/Logic Analyzer to D3
+  pinMode(3, OUTPUT); 
+  digitalWrite(3, LOW);
+
+  Serial.println("=== UWB In-Band Data TX Example ===");
+  Serial.println("Initializing UWB...");
+
+  UWB.registerRangingCallback(rangingHandler);
+  // Using INFO level for cleaner output. Use UWB_DEBUG_LEVEL for troubleshooting.
+  UWB.begin(Serial, uwb::LogLevel::UWB_INFO_LEVEL);
+
+  while (UWB.state() != 0) {
+    Serial.print(".");
+    delay(100);
+  }
+  Serial.println(" Done!");
+
+  Serial.println("Creating TX session...");
+  dataSession = new UWBInBandDataTx(0x11223344, srcAddr, dstAddr, 12);
+  UWBSessionManager.addSession(*dataSession);
+  dataSession->init();
+  dataSession->start();
+
+  Serial.println("Session started. Firmware will auto-send data from global buffer during ranging.");
+  Serial.println("");
+}
+
+void loop() {
+  unsigned long currentTime = millis();
+
+  // Update the global buffer every second
+  if (currentTime - lastUpdateTime >= UPDATE_INTERVAL) {
+    lastUpdateTime = currentTime;
+
+    // Create message
+    String message = "Hello #" + String(dataCounter);
+
+    // Send the data explicitly!
+    // Firmware does NOT auto-send. We must trigger it.
+    uwb::Status status = dataSession->sendData((uint8_t*)message.c_str(), message.length() + 1);
+
+    if (status == uwb::Status::SUCCESS) {
+        // Latency Measurement Pulse
+        // Pulse Pin 3 HIGH for 50us to satisfy logic analyzer trigger
+        digitalWrite(3, HIGH);
+        delayMicroseconds(50);
+        digitalWrite(3, LOW);
+
+        Serial.print("Sent: '");
+    } else {
+        Serial.print("Send FAILED: '");
+    }
+    Serial.print(message);
+    Serial.println("'");
+
+    dataCounter++;
+
+#if defined(ARDUINO_PORTENTA_C33)
+    digitalWrite(LEDR, !digitalRead(LEDR));
+#endif
+  }
+
+  delay(10);
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=PortentaUWBShield
-version=1.0.2
+version=1.0.3
 author=Pierpaolo Lento <pierpaolo.lento@truesense.it>
 maintainer=Pierpaolo Lento <pierpaolo.lento@truesense.it>
 sentence=Library for the Arduino Portenta C33 UWB Shield.

--- a/src/PortentaUWBShield.h
+++ b/src/PortentaUWBShield.h
@@ -11,4 +11,6 @@
 #include "uwbapps/UWBMultiSessionTag.hpp"
 #include "uwbapps/UWBUltdoaAnchor.hpp"
 #include "uwbapps/UWBUltdoaSyncAnchor.hpp"
+#include "uwbapps/UWBInbandDataRx.hpp"
+#include "uwbapps/UWBInbandDataTx.hpp"
 #endif

--- a/src/uwbapps/UWBInbandDataRx.hpp
+++ b/src/uwbapps/UWBInbandDataRx.hpp
@@ -4,10 +4,8 @@
 #ifndef UWBINBANDDATARX_HPP
 #define UWBINBANDDATARX_HPP
 
-extern "C" {
-    extern void *dataRcvNtfSemTx;
-    extern uint8_t dataReceived[];
-};
+// Global buffer that firmware writes to during ranging
+uint8_t dataReceived[116];  // MAX_APP_DATA_SIZE from uwb_types.hpp
 
 
 #include "UWB.hpp"
@@ -18,44 +16,54 @@ extern "C" {
 * This class will setup a ranging session with in-band data reception capabilities.
 * When the data is received it will be signaled in the userCallback by receiving a
 * notification of type DataReceived.
+* The data will be in the global dataReceived[] buffer.
 */
 
 class UWBInBandDataRx : public UWBSession {
-public:   
-    UWBInBandDataRx(uint32_t session_ID, UWBMacAddress srcAddr, 
+public:
+    UWBInBandDataRx(uint32_t session_ID, UWBMacAddress srcAddr,
                     UWBMacAddress dstAddr, uint32_t dataBlocks = 12)
-        : destination(dstAddr) 
+        : destination(dstAddr)
     {
         sessionID(session_ID);
-        sessionType(uwb::SessionType::RANGING_WITH_DATA_TRANSFER);
-        
+        sessionType(uwb::SessionType::DATA_TRANSFER);
+
         // Set ranging parameters using HAL types
-        rangingParams.setDeviceRole(uwb::DeviceRole::RESPONDER);
-        rangingParams.setDeviceType(uwb::DeviceType::CONTROLEE);
-        rangingParams.setMultiNodeMode(uwb::MultiNodeMode::UNICAST);
-        rangingParams.setRangingRoundUsage(uwb::RangingRoundUsage::DS_TWR);
-        rangingParams.setScheduleMode(uwb::ScheduleMode::TIME_SCHEDULED);
-        rangingParams.setDeviceMacAddr(srcAddr);
+        rangingParams.deviceRole(uwb::DeviceRole::RESPONDER);
+        rangingParams.deviceType(uwb::DeviceType::CONTROLEE);
+        rangingParams.multiNodeMode(uwb::MultiNodeMode::UNICAST);
+        rangingParams.rangingRoundUsage(uwb::RangingMethod::DS_TWR);
+        rangingParams.scheduledMode(uwb::ScheduledMode::TIME_SCHEDULED);
+        rangingParams.deviceMacAddr(srcAddr);
 
         // Set app parameters
-        appParams.addOrUpdateParam(AppConfigId::NO_OF_CONTROLEES, 
-                                    AppParamType::U32, 1);
-        appParams.setDstMacAddr(dstAddr);
-        setDefaults();
+        appParams.noOfControlees(1);
+        appParams.destinationMacAddr(dstAddr);
+        applyDefaults();
 
-        // Link layer and frame config
-        appParams.addOrUpdateParam(AppConfigId::LINK_LAYER_MODE, 
-                                    AppParamType::U32, 
-                                    static_cast<uint32_t>(uwb::LinkLayerMode::BYPASS));
-        appParams.addOrUpdateParam(AppConfigId::RFRAME_CONFIG, 
-                                    AppParamType::U32,
-                                    static_cast<uint32_t>(uwb::RFrameConfig::SP1));
+        // Timing parameters for ranging session
+        // appParams.rangingDuration(200);     // 200ms ranging duration
+        // appParams.slotPerRR(10);            // 10 slots per ranging round
+        // appParams.slotDuration(2400);       // 2400 RSTU = 2ms per slot
+
+        // Frame config for SP1 (supports data transfer)
+        appParams.frameConfig(1);  // SP1 configuration
 
         // Vendor specific data transfer parameters
-        vendorParams.addOrUpdateParam(VendorAppConfigId::SESSION_INBAND_DATA_TX_BLOCKS, 
-                                       AppParamType::U32, 0);
-        vendorParams.addOrUpdateParam(VendorAppConfigId::SESSION_INBAND_DATA_RX_BLOCKS, 
-                                       AppParamType::U32, dataBlocks);
+        uwb::VendorAppConfig txBlocks;
+        txBlocks.param_id = uwb::VendorAppConfigId::SESSION_INBAND_DATA_TX_BLOCKS;
+        txBlocks.param_type = uwb::AppParamType::U32;
+        txBlocks.param_value.vu32 = 0;
+        vendorParams.addOrUpdateParam(txBlocks);
+
+        uwb::VendorAppConfig rxBlocks;
+        rxBlocks.param_id = uwb::VendorAppConfigId::SESSION_INBAND_DATA_RX_BLOCKS;
+        rxBlocks.param_type = uwb::AppParamType::U32;
+        rxBlocks.param_value.vu32 = dataBlocks;
+        vendorParams.addOrUpdateParam(rxBlocks);
+
+        // Clear the buffer
+        memset(dataReceived, 0, sizeof(dataReceived));
     }
 
 private:

--- a/src/uwbapps/UWBInbandDataTx.hpp
+++ b/src/uwbapps/UWBInbandDataTx.hpp
@@ -4,7 +4,8 @@
 #ifndef UWBINBANDDATATX_HPP
 #define UWBINBANDDATATX_HPP
 
-extern "C" uint8_t dataToSend[];
+// Global buffer that firmware reads during ranging
+uint8_t dataToSend[116];  // MAX_APP_DATA_SIZE from uwb_types.hpp
 
 
 #include "UWB.hpp"
@@ -12,62 +13,82 @@ extern "C" uint8_t dataToSend[];
 #include "UWBMacAddress.hpp"
 
 class UWBInBandDataTx : public UWBSession {
-public: 
-    UWBInBandDataTx(uint32_t session_ID, UWBMacAddress srcAddr, 
+public:
+    UWBInBandDataTx(uint32_t session_ID, UWBMacAddress srcAddr,
                     UWBMacAddress dstAddr, uint32_t dataBlocks = 12)
-        : destination(dstAddr), sequence_number(0)
+        : destination(dstAddr)
     {
-        setSessionID(session_ID);
-        setSessionType(uwb::SessionType::RANGING_WITH_DATA_TRANSFER);
-        
+        sessionID(session_ID);
+        sessionType(uwb::SessionType::DATA_TRANSFER);
+
         // Set ranging parameters using HAL types
         rangingParams.deviceRole(uwb::DeviceRole::INITIATOR);
         rangingParams.deviceType(uwb::DeviceType::CONTROLLER);
         rangingParams.multiNodeMode(uwb::MultiNodeMode::UNICAST);
-        rangingParams.rangingRoundUsage(uwb::RangingRoundUsage::DS_TWR);
-        rangingParams.scheduleMode(uwb::ScheduleMode::TIME_SCHEDULED);
+        rangingParams.rangingRoundUsage(uwb::RangingMethod::DS_TWR);
+        rangingParams.scheduledMode(uwb::ScheduledMode::TIME_SCHEDULED);
         rangingParams.deviceMacAddr(srcAddr);
 
         // Set app parameters
-        appParams.addOrUpdateParam(AppConfigId::NO_OF_CONTROLEES, 
-                                    AppParamType::U32, 1);
-		appParams.dstMacAddr(dstAddr);
-        setDefaults();
+        appParams.noOfControlees(1);
+        appParams.destinationMacAddr(dstAddr);
+        applyDefaults();
 
-        // Link layer and frame config
-        appParams.addOrUpdateParam(AppConfigId::LINK_LAYER_MODE, 
-                                    AppParamType::U32, 
-                                    static_cast<uint32_t>(uwb::LinkLayerMode::BYPASS));
-									appParams.addOrUpdateParam(AppConfigId::RFRAME_CONFIG, 
-                                    AppParamType::U32,
-                                    static_cast<uint32_t>(uwb::RFrameConfig::SP1));
+        // Timing parameters for ranging session
+        // appParams.rangingDuration(200);     // 200ms ranging duration
+        // appParams.slotPerRR(10);            // 10 slots per ranging round
+        // appParams.slotDuration(2400);       // 2400 RSTU = 2ms per slot
+
+        // Frame config for SP1 (supports data transfer)
+        appParams.frameConfig(1);  // SP1 configuration
 
         // Vendor specific data transfer parameters
-        vendorParams.addOrUpdateParam(VendorAppConfigId::SESSION_INBAND_DATA_TX_BLOCKS, 
-                                       AppParamType::U32, dataBlocks);
-        vendorParams.addOrUpdateParam(VendorAppConfigId::SESSION_INBAND_DATA_RX_BLOCKS, 
-                                       AppParamType::U32, 0);
+        uwb::VendorAppConfig txBlocks;
+        txBlocks.param_id = uwb::VendorAppConfigId::SESSION_INBAND_DATA_TX_BLOCKS;
+        txBlocks.param_type = uwb::AppParamType::U32;
+        txBlocks.param_value.vu32 = dataBlocks;
+        vendorParams.addOrUpdateParam(txBlocks);
+
+        uwb::VendorAppConfig rxBlocks;
+        rxBlocks.param_id = uwb::VendorAppConfigId::SESSION_INBAND_DATA_RX_BLOCKS;
+        rxBlocks.param_type = uwb::AppParamType::U32;
+        rxBlocks.param_value.vu32 = 0;
+        vendorParams.addOrUpdateParam(rxBlocks);
+
+        // Initialize buffer
+        memset(dataToSend, 0, sizeof(dataToSend));
     }
 
-    uwb::Status sendData(uint8_t data[], uint16_t data_size) {
+    // Copy data to global buffer and Trigger Send
+    uwb::Status sendData(uint8_t* data, uint16_t data_size) {
+        if (data_size > sizeof(dataToSend)) {
+            data_size = sizeof(dataToSend);
+        }
+        memcpy(dataToSend, data, data_size);
+
         uwb::DataPacket packet;
         packet.session_handle = sessionHdl;
         memcpy(packet.mac_address, destination.getData(), destination.getSize());
-        packet.data = data;
+        packet.data = dataToSend; // Point to the global buffer
         packet.data_size = data_size;
-        packet.sequence_number = sequence_number;
+        packet.sequence_number = 0; // Sequence is handled by HAL/FW usually
 
         uwb::Status status = UWBHAL.sendData(packet);
         if (status != uwb::Status::SUCCESS) {
-            UWBHAL.Log_E("Failed to send data");
-        } else {
-            sequence_number++;
+            UWBHAL.Log_E("Failed to send data: %d", status);
         }
         return status;
     }
 
+    // Helper to just set buffer without sending (Legacy support)
+    void setDataToSend(const uint8_t* data, uint16_t size) {
+        if (size > sizeof(dataToSend)) {
+            size = sizeof(dataToSend);
+        }
+        memcpy(dataToSend, data, size);
+    }
+
 private:
-    uint16_t sequence_number;
     UWBMacAddress destination;
 };
 

--- a/src/uwbapps/UWBRangingControlee.hpp
+++ b/src/uwbapps/UWBRangingControlee.hpp
@@ -9,12 +9,14 @@
 
 class  UWBRangingControlee:public UWBSession {
 
-public: 
-	    
+public:
+
 	UWBRangingControlee(uint32_t session_ID, UWBMacAddress srcAddr, UWBMacAddress dstAddr)
 	{
 		sessionID(session_ID);
 		sessionType(uwb::SessionType::RANGING);
+
+		// Ranging parameters
 		rangingParams.deviceRole(uwb::DeviceRole::RESPONDER);
 		rangingParams.deviceType(uwb::DeviceType::CONTROLEE);
 		rangingParams.multiNodeMode(uwb::MultiNodeMode::UNICAST);
@@ -22,21 +24,21 @@ public:
 		rangingParams.scheduledMode(uwb::ScheduledMode::TIME_SCHEDULED);
 		rangingParams.macAddrMode((uint8_t)uwb::MacAddressMode::SHORT);
 		rangingParams.deviceMacAddr(srcAddr);
-		
-		
-		
-	    appParams.destinationMacAddr(dstAddr);
-	    appParams.frameConfig(uwb::RfFrameConfig::SP3);
-		appParams.slotPerRR(25);
-		appParams.rangingDuration(200);
+
+		// Application parameters - must match controller exactly
+		appParams.noOfControlees(1);              // Explicit: 1 controlee
+		appParams.destinationMacAddr(dstAddr);
+		appParams.frameConfig(uwb::RfFrameConfig::SP3);
 		appParams.stsConfig(uwb::StsConfig::StaticSts);
 		appParams.stsSegments(1);
-		appParams.sfdId(2);
-		appParams.preambleCodeIndex(10);	
-		
-   
-	}
-	
+		appParams.sfdId(2);                       // 64-bit SFD for better accuracy
+		appParams.preambleCodeIndex(10);
+		appParams.slotDuration(2400);             // 2400 RSTU = 2ms per slot
+		appParams.slotPerRR(25);                  // 25 slots per ranging round
+		appParams.rangingDuration(200);           // 200ms ranging interval
+
+}
+
 };
 
-#endif
+#endif/* UWBRANGINGCONTROLEE */

--- a/src/uwbapps/UWBRangingController.hpp
+++ b/src/uwbapps/UWBRangingController.hpp
@@ -10,30 +10,35 @@
 
 class  UWBRangingController:public UWBSession {
 
-public:     
-	UWBRangingController(uint32_t session_ID, UWBMacAddress srcAddr, UWBMacAddress dstAddr)
+public:
+UWBRangingController(uint32_t session_ID, UWBMacAddress srcAddr, UWBMacAddress dstAddr)
 	{
 		sessionID(session_ID);
 		sessionType(uwb::SessionType::RANGING);
+
+		// Ranging parameters
 		rangingParams.deviceRole(uwb::DeviceRole::INITIATOR);
 		rangingParams.deviceType(uwb::DeviceType::CONTROLLER);
 		rangingParams.multiNodeMode(uwb::MultiNodeMode::UNICAST);
 		rangingParams.rangingRoundUsage(uwb::RangingMethod::DS_TWR);
 		rangingParams.scheduledMode(uwb::ScheduledMode::TIME_SCHEDULED);
+		rangingParams.macAddrMode((uint8_t)uwb::MacAddressMode::SHORT);
 		rangingParams.deviceMacAddr(srcAddr);
-		
-	
-		appParams.noOfControlees(1);
-	    appParams.destinationMacAddr(dstAddr);	        
+
+		// Application parameters - must match controlee exactly
+		appParams.noOfControlees(1);              // Explicit: 1 controlee
+		appParams.destinationMacAddr(dstAddr);
 		appParams.frameConfig(uwb::RfFrameConfig::SP3);
-		appParams.slotPerRR(25);		
-		appParams.rangingDuration(200);
 		appParams.stsConfig(uwb::StsConfig::StaticSts);
-		appParams.sfdId(2);
-		appParams.preambleCodeIndex(10);	
-	
-		
-	}	
+		appParams.stsSegments(1);
+		appParams.sfdId(2);                       // 64-bit SFD for better accuracy
+		appParams.preambleCodeIndex(10);
+		appParams.slotDuration(2400);             // 2400 RSTU = 2ms per slot
+		appParams.slotPerRR(25);                  // 25 slots per ranging round
+		appParams.rangingDuration(200);           // 200ms ranging interval
+
+}
+
 };
 
 #endif/* UWBRANGINGCONTROLLER */


### PR DESCRIPTION
…ansfer examples (v1.0.3)

This PR addresses recent compatibility issues with the latest Arduino IDE and Renesas Portenta cores, and introduces two new examples for UWB in-band data transfer.

Fixes
Packaging Issue: Fixed the `undefined reference to UWBHAL` linker error. The precompiled library (`libUWBShieldApi.a`) was moved from `src/cortex-m33/fpv5-sp-d16-hard/` to `src/cortex-m33/` to match the updated path expectations of the latest Arduino core.

 New Examples
Added `UWB_InbandDataRx` example to demonstrate receiving data over the UWB connection. Added `UWB_InbandDataTx` example to demonstrate transmitting data over the UWB connection.

Versioning
Bumped library version to `1.0.3` in `library.properties`.